### PR TITLE
Add support for beta.krautchan.net

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -130,6 +130,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 
                 <data android:host="krautchan.net" />
                 <data android:host="www.krautchan.net" />
+                <data android:host="beta.krautchan.net" />
                 
                 <data android:host="7chan.org" />
                 

--- a/src/nya/miku/wishmaster/chans/krautchan/KrautModule.java
+++ b/src/nya/miku/wishmaster/chans/krautchan/KrautModule.java
@@ -75,7 +75,7 @@ public class KrautModule extends CloudflareChanModule {
     private static final String TAG = "KrautModule";
     
     static final String CHAN_NAME = "krautchan.net";
-    private static final String CHAN_DOMAIN = "krautchan.net";
+    private static final String CHAN_DOMAIN = "beta.krautchan.net";
     
     private static final String PREF_KEY_KOMPTURCODE_COOKIE = "PREF_KEY_KOMPTURCODE_COOKIE";
     


### PR DESCRIPTION
Apparently, KC was moved to a new subdomain, this pull requests adds support for it.