### PR TITLE
Bump versionCode to allow F-Droid update

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     package="nya.miku.wishmaster"
     android:installLocation="auto"
     tools:ignore="UnusedAttribute"
-    android:versionCode="68"
+    android:versionCode="1063"
     android:versionName="1.6.3">
 
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
В F-Droid отсутствует свежая версия приложения, т.к. versionCode [версии 1.0.2](https://github.com/AliceCA/Overchan-Android/blob/v1.0.2_fdroid/AndroidManifest.xml#L24) больше, чем всех последующих.