### PR TITLE
Fix access to uppercase boards

### DIFF
--- a/src/nya/miku/wishmaster/api/AbstractLynxChanModule.java
+++ b/src/nya/miku/wishmaster/api/AbstractLynxChanModule.java
@@ -375,7 +375,6 @@ public abstract class AbstractLynxChanModule extends AbstractWakabaModule {
         return url;
     }
 
-    //TODO: parse case-sensitive board names
     @Override
     public UrlPageModel parseUrl(String url) throws IllegalArgumentException {
         String urlPath = UrlPathUtils.getUrlPath(url, getAllDomains());
@@ -393,7 +392,7 @@ public abstract class AbstractLynxChanModule extends AbstractWakabaModule {
             } catch (Exception e) {
             }
         }
-        UrlPageModel model = WakabaUtils.parseUrlPath(urlPath, getChanName());
+        UrlPageModel model = WakabaUtils.parseUrlPath(urlPath, getChanName(), false);
         if ((model.type == UrlPageModel.TYPE_BOARDPAGE) && (model.boardPage < 1)) {
             model.boardPage = 1;
         }

--- a/src/nya/miku/wishmaster/api/util/WakabaUtils.java
+++ b/src/nya/miku/wishmaster/api/util/WakabaUtils.java
@@ -61,7 +61,11 @@ public class WakabaUtils {
     }
     
     public static UrlPageModel parseUrlPath(String path, String chanName) {
-        path = path.toLowerCase(Locale.US);
+        return parseUrlPath(path, chanName, true);
+    }
+    
+    public static UrlPageModel parseUrlPath(String path, String chanName, boolean caseInsensitive) {
+        if (caseInsensitive) path = path.toLowerCase(Locale.US);
         
         UrlPageModel model = new UrlPageModel();
         model.chanName = chanName;


### PR DESCRIPTION
Default behaviour of Wakaba URL path parser prevents to open boards with names in upper case.
Most of imageboards use board names in lower case only, but Lynxchan-based imageboards such as Endchan have case sensitive names. So at this moment request to Endchan `/AM/` will be redirected to `/am/` that is the another board.